### PR TITLE
cider compatibility

### DIFF
--- a/expectations-mode.el
+++ b/expectations-mode.el
@@ -244,7 +244,7 @@ it."
 (defun expectations-display-compilation-buffer (out)
   (with-current-buffer (get-buffer-create "*expectations*")
     (expectations-results-mode)
-    (nrepl-emit-into-color-buffer (current-buffer) out)
+    (cider-emit-into-color-buffer (current-buffer) out)
     (display-buffer (current-buffer))
     (setq next-error-last-buffer (current-buffer))
     (compilation-set-window-height (get-buffer-window "*expectations*"))))


### PR DESCRIPTION
I replaced nrepl-functions with the cider-equivalents where necessary.

This would probably need some more testing before merge, since I just tested running tests on one of my test files using `C-c ,`.
