### PR TITLE
Add CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,11 @@
 version: 2.1
 
-########################################################################################################################
-#                                                      EXECUTORS                                                       #
-########################################################################################################################
-
-executors:
-  default:
-    working_directory: /home/circleci/camsaul/expectations-mode/
-    docker:
-      - image: xueyouchao/docker-alpine-emacs
-
-
-########################################################################################################################
-#                                                       COMMANDS                                                       #
-########################################################################################################################
-
 jobs:
 
   checkout:
-    executor: default
+    docker:
+      - image: alpine/git
+    working_directory: /home/circleci/clojure-expectations/expectations-mode/
     steps:
       - restore_cache:
           keys:
@@ -33,42 +20,24 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci/
           paths:
-            - camsaul/expectations-mode
-
-  fetch-package-lint:
-    executor: default
-    steps:
-      - restore_cache:
-          keys:
-            - package-lint-{{ .Branch }}-{{ .Revision }}
-            - package-lint-{{ .Branch }}
-            - package-lint-
-      - run: git clone https://github.com/purcell/package-lint.git /home/circleci/package-lint
-      - save_cache:
-          key: package-lint-{{ .Branch }}
-          paths:
-            - /home/circleci/package-lint/.git
-      - persist_to_workspace:
-          root: /home/circleci/
-          paths:
-            - package-lint
+            - clojure-expectations/expectations-mode
 
   package-lint:
-    executor: default
+    docker:
+      - image: camsaul/docker-emacs-package-lint
+    working_directory: /home/circleci/clojure-expectations/expectations-mode/
     steps:
       - attach_workspace:
           at: /home/circleci/
       - run:
           name: Run package-lint
-          command: emacs
+          command: emacs -Q -nw -batch -l /usr/local/package-lint.el -f package-lint-batch-and-exit expectations-mode.el
 
 workflows:
   version: 2
   build:
     jobs:
       - checkout
-      - fetch-package-lint
       - package-lint:
           requires:
             - checkout
-            - fetch-package-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,31 @@ jobs:
           paths:
             - clojure-expectations/expectations-mode
 
+  # install-cider:
+  #   docker:
+  #     - image: camsaul/docker-emacs-package-lint
+  #   working_directory: /home/circleci/clojure-expectations/expectations-mode/
+  #   steps:
+  #     - attach_workspace:
+  #         at: /home/circleci/
+  #     - restore_cache:
+  #         keys:
+  #           - cider-{{ .Branch }}-{{ .Revision }}
+  #           - cider-{{ .Branch }}
+  #           - cider-
+  #     - run:
+  #         name: Install CIDER
+  #         command: emacs -Q -nw -batch -l /home/circleci/clojure-expectations/expectations-mode/.circleci/install-cider.el
+  #         no_output_timeout: 5m
+  #     - save_cache:
+  #         key: cider-{{ .Branch }}-{{ .Revision }}
+  #         paths:
+  #           - /home/emacs/.emacs.d/elpa
+  #     - persist_to_workspace:
+  #         root: /home/emacs/
+  #         paths:
+  #           - .emacs.d/elpa
+
   package-lint:
     docker:
       - image: camsaul/docker-emacs-package-lint
@@ -30,14 +55,18 @@ jobs:
       - attach_workspace:
           at: /home/circleci/
       - run:
-          name: Run package-lint
+          name: Install cider locally & run package-lint
           command: emacs -Q -nw -batch -l /usr/local/package-lint.el -f package-lint-batch-and-exit expectations-mode.el
+          no_output_timeout: 5m
 
 workflows:
   version: 2
   build:
     jobs:
       - checkout
+      # - install-cider:
+      #     requires:
+      #       - checkout
       - package-lint:
           requires:
-            - checkout
+            # - install-cider

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,74 @@
+version: 2.1
+
+########################################################################################################################
+#                                                      EXECUTORS                                                       #
+########################################################################################################################
+
+executors:
+  default:
+    working_directory: /home/circleci/camsaul/expectations-mode/
+    docker:
+      - image: xueyouchao/docker-alpine-emacs
+
+
+########################################################################################################################
+#                                                       COMMANDS                                                       #
+########################################################################################################################
+
+jobs:
+
+  checkout:
+    executor: default
+    steps:
+      - restore_cache:
+          keys:
+            - source-{{ .Branch }}-{{ .Revision }}
+            - source-{{ .Branch }}
+            - source-
+      - checkout
+      - save_cache:
+          key: source-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .git
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - camsaul/expectations-mode
+
+  fetch-package-lint:
+    executor: default
+    steps:
+      - restore_cache:
+          keys:
+            - package-lint-{{ .Branch }}-{{ .Revision }}
+            - package-lint-{{ .Branch }}
+            - package-lint-
+      - run: git clone https://github.com/purcell/package-lint.git /home/circleci/package-lint
+      - save_cache:
+          key: package-lint-{{ .Branch }}
+          paths:
+            - /home/circleci/package-lint/.git
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - package-lint
+
+  package-lint:
+    executor: default
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run package-lint
+          command: emacs
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - checkout
+      - fetch-package-lint
+      - package-lint:
+          requires:
+            - checkout
+            - fetch-package-lint

--- a/.circleci/install-cider.el
+++ b/.circleci/install-cider.el
@@ -1,0 +1,8 @@
+(require 'package)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+(package-initialize)
+
+(unless (package-installed-p 'cider)
+  (setq network-security-level 'low)
+  (package-refresh-contents)
+  (package-install 'cider))

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/
 project.clj
 .lein*
 checkouts/
+*flycheck*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Expectations Mode
 
-[![Circle CI](https://circleci.com/gh/camsaul/expectations-mode.svg?style=svg)](https://circleci.com/gh/camsaul/expectations-mode)
+[![Circle CI](https://circleci.com/gh/clojure-expectations/expectations-mode.svg?style=svg)](https://circleci.com/gh/clojure-expectations/expectations-mode)
 
 A minor Emacs mode for running
 [Expectations](https://github.com/jaycfields/expectations), based upon

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Expectations Mode
 
+[![Circle CI](https://circleci.com/gh/camsaul/expectations-mode.svg?style=svg)](https://circleci.com/gh/camsaul/expectations-mode)
+
 A minor Emacs mode for running
 [Expectations](https://github.com/jaycfields/expectations), based upon
 [Clojure test
@@ -14,7 +16,7 @@ nrepl. Going forward, I will only be supporting the nrepl code.
 
 *Please note Expectations v1.3.7 or greater is required to use expectations-mode.*
 
-You can either install the package manually or use the package manager package.el. 
+You can either install the package manually or use the package manager package.el.
 
 To install using the package manager, add the marmalade repo to your package-archives:
 
@@ -80,7 +82,7 @@ C-c '    show message for test under cursor
 
 The keybindings are a subset of the bindings used in
 `clojure-test-mode` and work the same way.
- 
+
 The shortcuts to run individual tests are not required, as you
 generally use the `-focus` version of the expectations macros to run
 an expectation in isolation.


### PR DESCRIPTION
I was about to open a PR to add this to MELPA as requested in #15 but I realized it's failing the [package-lint](https://github.com/purcell/package-lint). So I slapped together a Docker image to run Emacs & package lint and then added that to CI so we can see at a glance whether a PR is going to run afoul of nice Emacs Lisp conventions. 

Here's a sample run from my fork

https://circleci.com/gh/camsaul/expectations-mode/14